### PR TITLE
Fix -fconstrain-shift-value flag

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -483,7 +483,7 @@ ENUM_CODEGENOPT(ZeroCallUsedRegs, llvm::ZeroCallUsedRegs::ZeroCallUsedRegsKind,
 CODEGENOPT(OpaquePointers, 1, 0)
 
 /// Whether to constrain left or right shift value.
-CODEGENOPT(NoConstrainShiftValue, 1, 0)
+CODEGENOPT(ConstrainShiftValue, 1, 0)
 
 #undef CODEGENOPT
 #undef ENUM_CODEGENOPT

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1944,10 +1944,10 @@ defm delete_null_pointer_checks : BoolFOption<"delete-null-pointer-checks",
   BothFlags<[CoreOption]>>;
 
 defm constrain_shift_value : BoolFOption<"constrain-shift-value",
-  CodeGenOpts<"NoConstrainShiftValue">, DefaultFalse,
-  PosFlag<SetFalse, [], "Do not treat oversized shift as undefined behavior">,
-  NegFlag<SetTrue, [CC1Option], "Treat usage of oversized shift as undefined behavior (default)">,
-  BothFlags<[CoreOption]>>;
+  CodeGenOpts<"ConstrainShiftValue">, DefaultFalse,
+  PosFlag<SetTrue, [], "Do not treat oversized shift as undefined behavior">,
+  NegFlag<SetFalse, [], "Treat usage of oversized shift as undefined behavior (default)">,
+  BothFlags<[CC1Option]>>;
 
 def frewrite_map_file_EQ : Joined<["-"], "frewrite-map-file=">,
                            Group<f_Group>,

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -3936,7 +3936,7 @@ Value *ScalarExprEmitter::EmitShl(const BinOpInfo &Ops) {
   bool SanitizeBase = SanitizeSignedBase || SanitizeUnsignedBase;
   bool SanitizeExponent = CGF.SanOpts.has(SanitizerKind::ShiftExponent);
   // OpenCL 6.3j: shift values are effectively % word size of LHS.
-  if (CGF.getLangOpts().OpenCL || !CGF.CGM.getCodeGenOpts().NoConstrainShiftValue)
+  if (CGF.getLangOpts().OpenCL || CGF.CGM.getCodeGenOpts().ConstrainShiftValue)
     RHS = ConstrainShiftValue(Ops.LHS, RHS, "shl.mask");
   else if ((SanitizeBase || SanitizeExponent) &&
            isa<llvm::IntegerType>(Ops.LHS->getType())) {
@@ -4005,7 +4005,7 @@ Value *ScalarExprEmitter::EmitShr(const BinOpInfo &Ops) {
     RHS = Builder.CreateIntCast(RHS, Ops.LHS->getType(), false, "sh_prom");
 
   // OpenCL 6.3j: shift values are effectively % word size of LHS.
-  if (CGF.getLangOpts().OpenCL || !CGF.CGM.getCodeGenOpts().NoConstrainShiftValue)
+  if (CGF.getLangOpts().OpenCL || CGF.CGM.getCodeGenOpts().ConstrainShiftValue)
     RHS = ConstrainShiftValue(Ops.LHS, RHS, "shr.mask");
   else if (CGF.SanOpts.has(SanitizerKind::ShiftExponent) &&
            isa<llvm::IntegerType>(Ops.LHS->getType())) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -53,6 +53,7 @@
 #include "llvm/Support/TargetParser.h"
 #include "llvm/Support/YAMLParser.h"
 #include <cctype>
+#include <iostream>
 
 using namespace clang::driver;
 using namespace clang::driver::tools;
@@ -5109,7 +5110,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (!Args.hasFlag(options::OPT_fconstrain_shift_value,
                    options::OPT_fno_constrain_shift_value, false))
     CmdArgs.push_back("-fno-constrain-shift-value");
-
+  else
+    CmdArgs.push_back("-fconstrain-shift-value");
   // LLVM Code Generator Options.
 
   for (const Arg *A : Args.filtered(options::OPT_frewrite_map_file_EQ)) {


### PR DESCRIPTION
Some tests were failing because clang was called with -cc1 and the default behavior was to enable -fconstrain-shift-value. Additionally, I got rid of the weird logic of "!NoConstrainShiftValue" and replaced it with "ConstrainShiftValue".